### PR TITLE
GCI-25 Add a "delete release" button

### DIFF
--- a/app/js/showControllers.js
+++ b/app/js/showControllers.js
@@ -62,6 +62,28 @@ angular.module('modulusOne.showControllers', [
       }
     }
 
+    $scope.confirmDeleteRelease = function(releaseIndex) {
+      if (Config.api.readOnly) {
+        readonlyAlert.open()
+        return false
+      }
+
+      var release = $scope.module.releases[releaseIndex];
+      var message;
+      if($scope.module.releases.length == 1) {
+        message = 'You are deleting the only release of "' + $scope.module.name + '" '
+           + 'Would you like to keep this module\'s metadata in the system, or delete the module entirely?';
+      } else {
+        message = '"' + $scope.module.name + '" version "' + release.moduleVersion + '" will be deleted.';
+      }
+      if (confirm(message)) {
+        release.remove()
+        .finally(function() {
+          $scope.module.releases.splice(releaseIndex, 1);
+        })
+      }
+    }
+
     $scope.incrementDownload = function() {
       $scope.latestRelease.downloadCount++;
       $scope.module.downloadCount++

--- a/app/js/showControllers.js
+++ b/app/js/showControllers.js
@@ -2,7 +2,7 @@ angular.module('modulusOne.showControllers', [
   'ui'
 ])
 .controller('ShowModuleCtrl', function($scope, module, Restangular, $stateParams,
-    $state, getModule, $rootScope, readonlyAlert, Config, AuthService) {
+    $state, getModule, $rootScope, readonlyAlert, Config, AuthService, $modal) {
 
     $scope.module = module;
     $rootScope.title = $scope.module.name;
@@ -69,19 +69,19 @@ angular.module('modulusOne.showControllers', [
       }
 
       var release = $scope.module.releases[releaseIndex];
-      var message;
-      if($scope.module.releases.length == 1) {
-        message = 'You are deleting the only release of "' + $scope.module.name + '" '
-           + 'Would you like to keep this module\'s metadata in the system, or delete the module entirely?';
-      } else {
-        message = '"' + $scope.module.name + '" version "' + release.moduleVersion + '" will be deleted.';
-      }
-      if (confirm(message)) {
+      var modal = $modal.open({
+        templateUrl: 'uponDeleteReleaseDialog.html',
+        scope: $scope,
+        controller: function ($scope) {
+          $scope.release = release;
+        }
+      });
+      modal.result.then(function() {
         release.remove()
         .finally(function() {
           $scope.module.releases.splice(releaseIndex, 1);
         })
-      }
+      })
     }
 
     $scope.incrementDownload = function() {

--- a/app/partials/showModule.html
+++ b/app/partials/showModule.html
@@ -123,7 +123,7 @@
   <div class="col-md-4">
     <p>
       <a ng-href="{{latestRelease.downloadURL}}" ng-click="incrementDownload()">
-        <button type="button" class="btn btn-primary btn-lg">Download</button>
+        <button type="button" class="btn btn-primary btn-lg" ng-disabled="{{module.releases.length == 0}}">Download</button>
       </a>
     </p>
 

--- a/app/partials/showModuleReleases.html
+++ b/app/partials/showModuleReleases.html
@@ -28,3 +28,29 @@ class="btn btn-link header-button">
     </td>
   </tr>
 </table>
+
+<script type="text/ng-template" id="uponDeleteReleaseDialog.html">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="close()">
+      &times;
+    </button>
+    <h4 class="modal-title">Are you sure you want to delete this release?</h4>
+  </div>
+  <div class="modal-body">
+    <p ng-if="module.releases.length == 1">
+      You are deleting the only release of "{{module.name}}"
+      Would you like to keep this module's metadata in the system, or delete the module entirely?
+    </p>
+    <p ng-if="module.releases.length != 1">
+      "{{module.name}}" version "{{release.moduleVersion}}" will be deleted.
+    </p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-danger" ng-click="$close()">
+      Delete this release
+    </button>
+    <button type="button" class="btn btn-default" ng-click="$dismiss()">
+      Cancel
+    </button>
+  </div>
+</script>

--- a/app/partials/showModuleReleases.html
+++ b/app/partials/showModuleReleases.html
@@ -22,6 +22,9 @@ class="btn btn-link header-button">
       <a ng-href="{{release.downloadURL}}">
         <button type="button" class="btn btn-default btn-xs">Download</button>
       </a>
+      <button class="btn btn-link btn-warning" ng-if="user | canEdit:module"  ng-click="confirmDeleteRelease($index)">
+        <span class="glyphicon glyphicon-trash"></span>Delete
+      </button>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
For [this Issue](https://issues.openmrs.org/browse/GCI-25):

Module maintainers can delete releases. The download button is disabled when there are no releases.