### PR TITLE
GCI-62/MOD-87: only scroll down when page is in upload new release state

### DIFF
--- a/app/partials/showModule.html
+++ b/app/partials/showModule.html
@@ -142,5 +142,5 @@
 </div>
 
 <div class="row col-md-12 release-list release-view-container">
-  <div ui-view="release" autoscroll="true" class="release-view-animate"></div>
+  <div ui-view="release" class="release-view-animate"></div>
 </div>

--- a/app/partials/showModuleNewRelease.html
+++ b/app/partials/showModuleNewRelease.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="css/create.css"> 
 
-<h2>Releases</h2>
+<h2 id="releases-header">Releases</h2>
 
 <button ng-if="user | canEdit:module" ui-sref="show"
 class="btn btn-link header-button">
@@ -62,3 +62,7 @@ class="btn btn-link header-button">
 
 
 </div>
+
+<script>
+$(window).scrollTop($("#releases-header").offset().top)
+</script>


### PR DESCRIPTION
Fix [GCI-62](http://issues.openmrs.org/browse/GCI-62) / [MOD-87](https://issues.openmrs.org/browse/MOD-87) ([Melange task](http://www.google-melange.com/gci/task/view/google/gci2014/5296652202016768)).

I replaced the `autoscroll="true"` with a small script for two reasons:

 - I couldn't find any documentation on how it works at all (I might be looking in the wrong places)
 - I couldn't make the page scroll with it in `showModuleNewRelease.html`.

This seems to be reliable, and documented widely. As always, feedback welcome!