### PR TITLE
MOD-87: Keep page from scrolling down on every page load

### DIFF
--- a/app/js/showControllers.js
+++ b/app/js/showControllers.js
@@ -21,6 +21,10 @@ angular.module('modulusOne.showControllers', [
     // Allow the view to access the logged-in user.
     $scope.user = AuthService.user;
 
+    // Method to tell if we should autoscroll to the bottom of the page
+    $scope.autoscrollToRelease = function () {
+      return $state.is("show.newRelease");
+    }
 
     // Editability
     $scope.editable = false

--- a/app/partials/showModule.html
+++ b/app/partials/showModule.html
@@ -142,5 +142,5 @@
 </div>
 
 <div class="row col-md-12 release-list release-view-container">
-  <div ui-view="release" class="release-view-animate"></div>
+  <div ui-view="release" autoscroll="autoscrollToRelease()" class="release-view-animate"></div>
 </div>

--- a/app/partials/showModule.html
+++ b/app/partials/showModule.html
@@ -142,5 +142,5 @@
 </div>
 
 <div class="row col-md-12 release-list release-view-container">
-  <div ui-view="release" autoscroll="true" class="release-view-animate"></div>
+  <div ui-view="release" class="release-view-animate"></div>
 </div>

--- a/app/partials/showModule.html
+++ b/app/partials/showModule.html
@@ -22,7 +22,7 @@
 
 </div>
 
-<div class="row col-md-8" autoscroll="false">
+<div class="row col-md-8">
 
   <h2 class="module-name" ng-if="!editable">{{module.name}}</h2>
   <h2 ng-if="editable">

--- a/app/partials/showModuleNewRelease.html
+++ b/app/partials/showModuleNewRelease.html
@@ -10,8 +10,6 @@ class="btn btn-link header-button">
 <div class="row">
 
   <div class="jumbotron upload-jumbotron" ng-controller="ReleaseFileCtrl"
-  ui-view
-  autoscroll="true"
   ng-file-drop="onFileSelect($files)"
   ng-file-drag-over-class="upload-jumbotron-dragged"
   ng-file-drop-available="dropSupported=true">

--- a/app/partials/showModuleNewRelease.html
+++ b/app/partials/showModuleNewRelease.html
@@ -10,7 +10,7 @@ class="btn btn-link header-button">
 <div class="row">
 
   <div class="jumbotron upload-jumbotron" ng-controller="ReleaseFileCtrl"
-  ui-view="upload_new_release"
+  ui-view
   autoscroll="true"
   ng-file-drop="onFileSelect($files)"
   ng-file-drag-over-class="upload-jumbotron-dragged"

--- a/app/partials/showModuleNewRelease.html
+++ b/app/partials/showModuleNewRelease.html
@@ -2,7 +2,7 @@
 <h2>Releases</h2>
 
 <button ng-if="user | canEdit:module" ui-sref="show"
-class="btn btn-link header-button" ui-view="release" autoscroll='true'>
+class="btn btn-link header-button" ui-view="release">
   <span class="glyphicon glyphicon-list"></span>Show Releases
 </button>
 

--- a/app/partials/showModuleNewRelease.html
+++ b/app/partials/showModuleNewRelease.html
@@ -10,6 +10,8 @@ class="btn btn-link header-button">
 <div class="row">
 
   <div class="jumbotron upload-jumbotron" ng-controller="ReleaseFileCtrl"
+  ui-view="upload_new_release"
+  autoscroll="true"
   ng-file-drop="onFileSelect($files)"
   ng-file-drag-over-class="upload-jumbotron-dragged"
   ng-file-drop-available="dropSupported=true">


### PR DESCRIPTION
My second attempt at [GCI-62](https://issues.openmrs.org/browse/GCI-62) | [MOD-87](https://issues.openmrs.org/browse/MOD-87) ([Melange task](http://www.google-melange.com/gci/task/view/google/gci2014/5296652202016768)).

I figured out why just added `autoscroll="true"` to showModuleNewRelease.html wasn't working by attempting to type a decent question into Stack Overflow - apparently the element with `autoscroll="true"` needs to have a `ui-view` attribute. 

I agree that this is a much better approach than the one I took in #22 with the `<script>`'s, this doesn't require jQuery. Thanks for pointing that out!